### PR TITLE
add ETA #80

### DIFF
--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -34,5 +34,12 @@
   "transaction_link_copied": "Transaction Link Copied!",
   "beta_notice": "THIS PRODUCT IS IN BETA. USE AT YOUR OWN RISK.",
   "about": "About",
-  "iotx_Address": "IoTeX address"
+  "iotx_Address": "IoTeX address",
+  "eta": "ETA",
+  "eth_confirmations": "ETH confirmations",
+  "iotex_confirmations": "IoTeX confirmations",
+  "witness_confirmation": "Witness confirmations",
+  "min": "min",
+  "sec": "sec",
+  "may_delay_comment": "* may delay due to ETH network congestion."
 }

--- a/src/client/components/Footer/index.scss
+++ b/src/client/components/Footer/index.scss
@@ -3,7 +3,7 @@
   bottom: 0;
   right: 0;
   left: 0;
-  z-index: 0;
+  z-index: -1;
 
   .component__footer__content {
   }

--- a/src/client/pages/Home/components/CompleteFrame/index.tsx
+++ b/src/client/pages/Home/components/CompleteFrame/index.tsx
@@ -88,8 +88,33 @@ export const CompleteFrame = (props: IComponentProps) => {
           className="page__home__component__complete_frame__btn--copy cursor-pointer"
         />
       </div>
-      <div className="c-gray-30 font-light mt-3 mb-20 text-sm">
+      <div className="c-gray-30 font-light mt-3 mb-6 text-sm">
         {lang.t("complete.check_status_comment")}
+      </div>
+      <div className="text-sm c-gray-30 font-light mb-6">
+        <div className="flex justify-between items-center mb-2">
+          <span>{lang.t("eta")}</span>
+          <span>
+            ~{props.isERCXRC ? `4 ${lang.t("min")}` : `1 ${lang.t("min")}*`}
+          </span>
+        </div>
+        <div className="flex justify-between items-center mb-2">
+          <span>
+            {lang.t(
+              props.isERCXRC ? "eth_confirmations" : "iotex_confirmations"
+            )}
+          </span>
+          <span>
+            ~{props.isERCXRC ? `3 ${lang.t("min")}` : `5 ${lang.t("sec")}`}
+          </span>
+        </div>
+        <div className="flex justify-between items-center mb-2">
+          <span>{lang.t("witness_confirmation")}</span>
+          <span>
+            ~{props.isERCXRC ? `7 ${lang.t("sec")}` : `1 ${lang.t("min")}*`}
+          </span>
+        </div>
+        {!props.isERCXRC && <div>{lang.t("may_delay_comment")}</div>}
       </div>
       <Button
         className={`page__home__component__complete_frame__btn--complete bg-green-10 w-full ${


### PR DESCRIPTION
![Screen Shot 2020-08-28 at 5 57 59 AM](https://user-images.githubusercontent.com/34900782/91548636-a9b30480-e8f3-11ea-874e-9fa7cccb96d9.png)
![Screen Shot 2020-08-28 at 5 57 46 AM](https://user-images.githubusercontent.com/34900782/91548632-a6b81400-e8f3-11ea-902f-afbc1a760efe.png)

Pls check ETA labels only, ignore other empty fields(just tested by changing fields)